### PR TITLE
MCBBS Wiki模组联动

### DIFF
--- a/list_of_supported_mods.md
+++ b/list_of_supported_mods.md
@@ -12,4 +12,6 @@
 
 * 烤地瓜（Sweet Potato）：Pigeonia Featurehouse，[网址](https://github.com/teddyxlandlee/sweet_potato-source)
 
+* MCBBS Wiki 模组（MCBBS Wiki Mod）：QWERTY_52_38（Github账号QWERTY770），[网址](https://github.com/QWERTY770/MCBBS-Wiki-Mod)
+
 以下内容由于<*吃掉了*>的原因而无法显示，敬请谅jon'fslA;/[E-2L}sgr=


### PR DESCRIPTION
今天MCBBS Wiki模组增加了对此资源包的联动。需要0.8b2版本。见https://www.mcmod.cn/class/version/3343.html?jump=13233

repo地址：https://github.com/QWERTY770/MCBBS-Wiki-Mod
