### PR TITLE
[feat] mod support(SCP: Sharp)(#228)

### DIFF
--- a/list_of_supported_mods.md
+++ b/list_of_supported_mods.md
@@ -13,5 +13,6 @@
 * 矿物高亮（Bright ore）：Pigeonia Featurehouse，[网址](https://github.com/Featurehouse/bright-ore)
 * MCBBS Wiki 模组（MCBBS Wiki Mod）：QWERTY_52_38（Github账号QWERTY770），[网址](https://github.com/QWERTY770/MCBBS-Wiki-Mod)
 * 乡野与魔法（Countryside And Magic）：LAY Studio，[网址](https://github.com/CR-019/CAM_beta)
+* SCP: Sharp：xtexChooser，[网址](https://github.com/xtexChooser/scp-sharp)
 
 以下内容由于<*吃掉了*>的原因而无法显示，敬请谅jon'fslA;/[E-2L}sgr=


### PR DESCRIPTION
done #228 

[SCP: Sharp](https://github.com/xtexChooser/scp-sharp)是一个关于SCP基金会的MC模组，以LGPL-3.0协议（部分CC）发布。

模组本体现已包含对梗体中文的支持。

请求添加到mod兼容列表中。
